### PR TITLE
Fixed relative link not loading animation on post/sub pages

### DIFF
--- a/_includes/animated-illustration-footer.html
+++ b/_includes/animated-illustration-footer.html
@@ -12,9 +12,9 @@
     head.appendChild(script);
   }
   document.addEventListener("DOMContentLoaded", function(){
-    loadScript('js/cali1.js')
-    loadScript('js/cali2.js')
-    loadScript('js/sw1.js')
-    loadScript('js/ne1.js')
+    loadScript('/js/cali1.js')
+    loadScript('/js/cali2.js')
+    loadScript('/js/sw1.js')
+    loadScript('/js/ne1.js')
   });
 </script>


### PR DESCRIPTION
When viewing the post page(s) the animation files were attempting to load relative to the current page, causing the animation to no load.